### PR TITLE
Niall dev

### DIFF
--- a/app/controllers/status.js
+++ b/app/controllers/status.js
@@ -1,7 +1,13 @@
-var express =  require('express');
+var express = require('express');
 
-var app =  express();
-module.exports.getStatus = function(req, res) {
+var app = express();
+module.exports.getStatus = function (req, res) {
   var environment = process.env.NODE_ENV.toString();
-  res.render('status', {server: environment, numberOfUsers: "not yet defined"});
+  res.setHeader("Content-Type", 'application/json');
+  res.json({
+    'status': 'ok',
+    'server': environment,
+    'numberOfUsers': 'not yet defined'
+  });
 };
+

--- a/app/models/base.js
+++ b/app/models/base.js
@@ -3,7 +3,7 @@
  */
 
 var mongoose = require('mongoose');
-var config = require('config');
+var config = require('../../config/config');
 
 var Schema = mongoose.Schema;
 

--- a/app/views/status.html
+++ b/app/views/status.html
@@ -1,5 +1,0 @@
-{
-    "current environment": "{{ server }}",
-    "status": "ok",
-    "users online": "{{ numberOfUsers }}"
-}

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -6,6 +6,7 @@
 var fs = require('fs');
 var env = {};
 var envFile = __dirname + '/env.json';
+var config = require('../config');
 
 // Read env.json file, if it exists, load the id's and secrets from that
 // Note that this is only in the development env

--- a/config/express.js
+++ b/config/express.js
@@ -18,7 +18,7 @@ var mongoStore = require('connect-mongo')(session);
 var flash = require('connect-flash');
 var winston = require('winston');
 var helpers = require('view-helpers');
-var config = require('config');
+var config = require('./config');
 var pkg = require('../package.json');
 
 var env = process.env.NODE_ENV || 'development';

--- a/config/passport.js
+++ b/config/passport.js
@@ -16,13 +16,13 @@ module.exports = function (passport, config) {
   // serialize sessions
   passport.serializeUser(function(user, done) {
     done(null, user.id)
-  })
+  });
 
   passport.deserializeUser(function(id, done) {
     User.load({ criteria: { _id: id } }, function (err, user) {
       done(err, user)
     })
-  })
+  });
 
   // use these strategies
   passport.use(local);

--- a/config/passport/local.js
+++ b/config/passport/local.js
@@ -5,7 +5,7 @@
 
 var mongoose = require('mongoose');
 var LocalStrategy = require('passport-local').Strategy;
-var config = require('config');
+var config = require('../config');
 var User = mongoose.model('User');
 
 /**

--- a/config/routes.js
+++ b/config/routes.js
@@ -5,10 +5,10 @@
 // Note: We can require users, games and other cotrollers because we have
 // set the NODE_PATH to be ./app/controllers (package.json # scripts # start)
 
-var users = require('users');
-var games = require('games');
-var base = require('base');
-var status = require('status');
+var users = require('../app/controllers/users');
+var games = require('../app/controllers/games');
+var base = require('../app/controllers/base');
+var status = require('../app/controllers/status');
 var auth = require('./middlewares/authorization');
 
 /**

--- a/config/socket.js
+++ b/config/socket.js
@@ -1,6 +1,6 @@
-var users = require('users');
-var games = require('games');
-var base = require('base');
+var users = require('../app/controllers/users');
+var games = require('../app/controllers/games');
+var base = require('../app/controllers/base');
 var mongoose = require('mongoose');
 var Games = mongoose.model('Games');
 

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 var express = require('express');
 var mongoose = require('mongoose');
 var passport = require('passport');
-var config = require('config');
+var config = require('./config/config');
 
 var app = express();
 var port = process.env.PORT || 3000;

--- a/test/features/status.feature
+++ b/test/features/status.feature
@@ -1,7 +1,8 @@
 Feature: Health check on current server status
 
   Scenario: Server status is ok
+    Given The server is running in 'development' environment
     When I send a request to the server using the status endpoint
-    Then I get a message "ok"
-    And A HTTP status code of 200
+    Then I get http status 200
+    And The current environment should be 'development'
 

--- a/test/features/step_definitions/status.js
+++ b/test/features/step_definitions/status.js
@@ -10,21 +10,34 @@ var checkinStepsWrapper = function () {
   var assert = require('assert');
   var statusResponse;
 
+  this.Given(/^The server is running in '([^"]*)' environment$/, function(environment, next) {
+    process.env.NODE_ENV = environment;
+    next()
+  });
+
   this.When(/^I send a request to the server using the status endpoint$/, function (next) {
     request(app)
     .get('/status')
-    .expect(200)
-    .expect(/ok/);
+    .set('Content-Type', 'application/json')
+    .end(function(err, res) {
+      console.log(err);
+      statusResponse = res;
+      next();
+    });
   });
 
 
-  this.Then(/^I get a message "([^"]*)"$/, function (statusMessage, next) {
-    statusResponse.containDeep(statusMessage);
+  this.Then(/^I get http status (\d+)/, function (statusCode, next) {
+    statusResponse.statusCode.should.eql(parseInt(statusCode));
     next();
   });
 
-  this.Then(/^A HTTP status code of (\d+)$/, function (statusCode, callback) {
-    statusResponse.expect(statusCode);
+  this.Then(/The current environment should be '([^"]*)'$/, function (environment, next) {
+    responseBody = statusResponse.body;
+    responseBody.should.have.property('numberOfUsers');
+    responseBody.status.should.eql('ok');
+    responseBody.server.should.eql(environment);
+    next();
   });
 };
 


### PR DESCRIPTION
As mentioned in the commit:

Ramp up on Mocha (fixed Cucumber tests instead)
- Updated status controller
- Removed status.html as it is now displayed as JSON
- Added status controller test
- Used full relative path for require('config') and controllers. The reason for this is that when not using npm, eg, running individual tests or debugging the code, the system will read the variable path from the tests location. We should look into setting up the variable paths in the NODE_ENV configurations.
